### PR TITLE
fix: Holding down now drops the piece at the proper speec

### DIFF
--- a/src/tetris.ts
+++ b/src/tetris.ts
@@ -18,7 +18,7 @@ declare global {
 window.init = function(parent: string, assetRoot?: string) {
     window.game = new TetrisGame({
         parent: parent, width: CANVAS_WIDTH, height: CANVAS_HEIGHT,
-        assetRoot: assetRoot, keyRefreshMillis: 300, targetFps: 60,
+        assetRoot: assetRoot, targetFps: 60,
     });
     window.game.setState(new LoadingState(window.game));
     window.game.start();


### PR DESCRIPTION
Fixes #7. Because a key refire rate was specified in the game config, we didn't get the OS key refresh for key rotations, moving, and dropping via the arrow keys. This PR adds that.

Note this does mean that the game may respond to keyboard input slightly diffrently across different machines with different key refresh rates, but this is the closest to the actual game's behavior. An alternative could be to build this via a longer "initial" delay, then a shorter "repeat" delay, in the game code, but that's too much work considering the OS default is likely sufficient.